### PR TITLE
fix: decode redirection_url;  feat: add Thunderbird

### DIFF
--- a/src/network.ts
+++ b/src/network.ts
@@ -76,7 +76,7 @@ async function fetchURL(url: string): Promise<Result<string, string>> {
           e.response.status == 302 ||
           e.response.status == 303)
       ) {
-        resolve(new Ok(e.response.headers.location));
+        resolve(new Ok(decodeURI(e.response.headers.location)));
       } else {
         //console.log(e.response?.status)
         resolve(

--- a/tasks/Thunderbird/config.toml
+++ b/tasks/Thunderbird/config.toml
@@ -1,0 +1,44 @@
+# 任务基本信息
+[task]
+name = "Thunderbird"
+category = "实用工具"
+author = "wdw1007"
+url = "https://www.thunderbird.net"
+
+# 指定使用的模板
+[template]
+scraper = "Redirection_Parse"
+# resolver = ""
+producer = "Recursive_Unzip"
+
+# 使用到的正则
+[regex]
+# download_link = ''
+download_name = 'thunderbird.exe'
+# scraper_version = ''
+
+# 通用参数
+[parameter]
+# resolver_cd = []
+compress_level = 5
+build_manifest = ["${taskName}.wcs","${taskName}"]
+# build_cover = ""
+# build_delete = []
+
+# 爬虫模板临时参数
+
+[scraper_temp]
+redirection_url = "https://download.mozilla.org/?product=thunderbird-latest&os=win64&lang=zh-CN"
+
+# 自动制作模板要求的参数
+[producer_required]
+shortcutName = "Thunderbird"
+sourceFile = "thunderbird.exe"
+recursiveUnzipList = ["core"]
+
+
+# 额外备注
+# [extra]
+# require_windows = true
+# missing_version = ""
+weekly = true


### PR DESCRIPTION
代 [undefined](https://github.com/undefined-ux) 提交
修复使用 Redirection_Parse 模板时因返回的 url 未编码而导致的文件名版本号处出现多余的 "20"

添加 Thunderbird