### PR TITLE
feat: add 希沃白板5

### DIFF
--- a/src/aria2c.ts
+++ b/src/aria2c.ts
@@ -271,7 +271,7 @@ async function download_with_curl(
   }
 
   // 构造命令行
-  const cmd = ["curl", "-L", `-A "${UA}"`, `-o ${finalPath}`];
+  const cmd = ["curl", "-k", "-L", `-A "${UA}"`, `-o ${finalPath}`];
 
   if (options.referer) {
     cmd.push(`-e ${options.referer}`);
@@ -279,7 +279,7 @@ async function download_with_curl(
 
   // 开始下载
   try {
-    cp.execSync(`${cmd.join(" ")} ${url}`);
+    cp.execSync(`${cmd.join(" ")} "${url}"`);
   } catch (e) {
     throw new Error(`Error:Failed to download ${url} with curl : ${e}`);
   }

--- a/tasks/希沃白板5/config.toml
+++ b/tasks/希沃白板5/config.toml
@@ -1,0 +1,46 @@
+#:schema ../../schema/task.json
+# 任务基本信息
+[task]
+name = "希沃白板5"
+category = "网课会议"
+author = "狂犬主子"
+url = "https://baoku.360.cn/soft/show/appid/105036181"
+
+# 指定使用的模板
+[template]
+scraper = "Global_Page_Match"
+# resolver = ""
+producer = "Recursive_Unzip"
+
+# 使用到的正则
+[regex]
+# download_link = ''
+download_name = '\.exe'
+# scraper_version = ''
+
+# 通用参数
+[parameter]
+# resolver_cd = []
+# compress_level = 5
+build_manifest = ["${taskName}.wcs","${taskName}\\Main\\EasiNote.exe"]
+build_cover = "cover"
+# build_delete = []
+
+# 爬虫模板临时参数
+[scraper_temp]
+ua = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:127.0) Gecko/20100101 Firefox/127.0"
+version_selector = ".type-info"
+download_selector = ".normal-down-btn"
+
+# 自动制作模板要求的参数
+[producer_required]
+shortcutName = "希沃白板5"
+sourceFile = "Main\\EasiNote.exe"
+recursiveUnzipList = ['/EasiNote5_\d+.\d+.\d+.\d+/']
+
+
+# 额外备注
+# [extra]
+# require_windows = true
+# missing_version = ""
+# weekly = true

--- a/tasks/希沃白板5/config.toml
+++ b/tasks/希沃白板5/config.toml
@@ -4,11 +4,11 @@
 name = "希沃白板5"
 category = "网课会议"
 author = "xrgzs"
-url = "https://baoku.360.cn/soft/show/appid/105036181"
+url = "https://easinote.seewo.com/"
 
 # 指定使用的模板
 [template]
-scraper = "Global_Page_Match"
+scraper = "External"
 # resolver = ""
 producer = "Recursive_Unzip"
 
@@ -28,9 +28,9 @@ build_cover = "cover"
 
 # 爬虫模板临时参数
 [scraper_temp]
-ua = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:127.0) Gecko/20100101 Firefox/127.0"
-version_selector = ".type-info"
-download_selector = ".normal-down-btn"
+# download_path = "data.downloadUrl"
+# version_path = "data.softVersion"
+# api_url = "https://e.seewo.com/download/fromSeewoEdu?code=EasiNote5"
 
 # 自动制作模板要求的参数
 [producer_required]

--- a/tasks/希沃白板5/config.toml
+++ b/tasks/希沃白板5/config.toml
@@ -3,7 +3,7 @@
 [task]
 name = "希沃白板5"
 category = "网课会议"
-author = "狂犬主子"
+author = "xrgzs"
 url = "https://baoku.360.cn/soft/show/appid/105036181"
 
 # 指定使用的模板

--- a/tasks/希沃白板5/cover/Configs.fkv
+++ b/tasks/希沃白板5/cover/Configs.fkv
@@ -1,0 +1,9 @@
+> 配置文件
+> 版本 1.0
+DeviceCache.IsIwb
+True
+>
+DeviceInfo.Type
+228756AD-0620-497E-94FB-4022DB99C853
+>
+> 配置文件结束

--- a/tasks/希沃白板5/cover/希沃白板5.wcs
+++ b/tasks/希沃白板5/cover/希沃白板5.wcs
@@ -1,0 +1,25 @@
+FILE %ProgramFiles%\Edgeless\Configs.fkv=>X:\Users\Default\AppData\Seewo\EasiNote5\Data\Configs.fkv
+LINK X:\Users\Default\Desktop\Ï£ÎÖ°×°å5,%ProgramFiles%\Edgeless\Ï£ÎÖ°×°å5\Main\EasiNote.exe
+
+REGI  $HKEY_LOCAL_MACHINE\SOFTWARE\Classes\.enb\\=iseewo.enb
+REGI  $HKEY_LOCAL_MACHINE\SOFTWARE\Classes\.enbx\\=iseewo.enbx
+REGI  $HKEY_LOCAL_MACHINE\SOFTWARE\Classes\easinote\\=Ï£ÎÖ°×°å 5
+REGI  $HKEY_LOCAL_MACHINE\SOFTWARE\Classes\easinote\\URL Protocol=%ProgramFiles%\Edgeless\Ï£ÎÖ°×°å5\Main\EasiNote.exe
+
+REGI --k HKEY_LOCAL_MACHINE\SOFTWARE\Classes\easinote\shell\\=
+REGI  $HKEY_LOCAL_MACHINE\SOFTWARE\Classes\easinote\shell\open\\FriendlyAppName=Ï£ÎÖ°×°å 5
+REGI  $HKEY_LOCAL_MACHINE\SOFTWARE\Classes\easinote\shell\open\command\\="%ProgramFiles%\Edgeless\Ï£ÎÖ°×°å5\Main\EasiNote.exe" "%%1"
+REGI  $HKEY_LOCAL_MACHINE\SOFTWARE\Classes\iseewo.enb\\=Seewo EasiNote File
+REGI  $HKEY_LOCAL_MACHINE\SOFTWARE\Classes\iseewo.enb\DefaultIcon\\=%CurDir%\enb_file.ico
+
+REGI --k HKEY_LOCAL_MACHINE\SOFTWARE\Classes\iseewo.enb\shell\\=
+REGI  $HKEY_LOCAL_MACHINE\SOFTWARE\Classes\iseewo.enb\shell\open\\FriendlyAppName=Ï£ÎÖ°×°å 5
+REGI  $HKEY_LOCAL_MACHINE\SOFTWARE\Classes\iseewo.enb\shell\open\command\\=%ProgramFiles%\Edgeless\Ï£ÎÖ°×°å5\Main\EasiNote.exe "%%1"
+REGI  $HKEY_LOCAL_MACHINE\SOFTWARE\Classes\iseewo.enbx\\=Seewo EasiNote File
+REGI  $HKEY_LOCAL_MACHINE\SOFTWARE\Classes\iseewo.enbx\DefaultIcon\\=%CurDir%\enb_file.ico
+
+REGI --k HKEY_LOCAL_MACHINE\SOFTWARE\Classes\iseewo.enbx\shell\\=
+REGI  $HKEY_LOCAL_MACHINE\SOFTWARE\Classes\iseewo.enbx\shell\open\\FriendlyAppName=Ï£ÎÖ°×°å 5
+REGI  $HKEY_LOCAL_MACHINE\SOFTWARE\Classes\iseewo.enbx\shell\open\command\\=%ProgramFiles%\Edgeless\Ï£ÎÖ°×°å5\Main\EasiNote.exe "%%1"
+REGI  $HKEY_LOCAL_MACHINE\SOFTWARE\Classes\iseewo.enbx\shell\Ê¹ÓÃ Ï£ÎÖ°×°å 5 ¿ªÊ¼ÊÚ¿Î\\Icon=%ProgramFiles%\Edgeless\Ï£ÎÖ°×°å5\Main\EasiNote.exe
+REGI  $HKEY_LOCAL_MACHINE\SOFTWARE\Classes\iseewo.enbx\shell\Ê¹ÓÃ Ï£ÎÖ°×°å 5 ¿ªÊ¼ÊÚ¿Î\command\\="%ProgramFiles%\Edgeless\Ï£ÎÖ°×°å5\Main\EasiNote.exe" "%%1" -m Display

--- a/tasks/希沃白板5/scraper.ts
+++ b/tasks/希沃白板5/scraper.ts
@@ -1,0 +1,32 @@
+import { Ok, Err, Result } from "ts-results";
+import { ScraperReturned } from "../../src/class";
+
+export default async function (): Promise<Result<ScraperReturned, string>> {
+  // YOUR CODE HERE
+
+  // 尝试从指定URL获取下载信息
+  try {
+    // 发起GET请求获取下载信息
+    const res = await fetch(
+      "https://e.seewo.com/download/fromSeewoEdu?code=EasiNote5",
+      { method: "GET" },
+    );
+    // 如果请求不成功，则返回错误信息
+    if (!res.ok) {
+      return new Err(`Failed to fetch data: ${res.status} ${res.statusText}`);
+    }
+    // 解析并验证响应数据格式
+    const resp = await res.json();
+    if (typeof resp !== "object" || !("downloadUrl" in resp.data)) {
+      return new Err("Invalid response format");
+    }
+    // 如果数据有效，返回下载链接信息
+    return new Ok({
+      version: resp.data.downloadUrl,
+      downloadLink: resp.data.downloadUrl,
+    });
+    // 如果发生异常，返回错误信息
+  } catch (err) {
+    return new Err(`Fetch error: ${err}`);
+  }
+}


### PR DESCRIPTION
希沃白板5，是一款专门针对教学场景设计的互动课件工具，提供课件云同步、学科工具、思维导图、课堂活动、超级分类等多种备授课常用功能，只需简单的操作就能让您的知识点跃然呈现。

此处对安装包进行解压，关联上相关的文件格式。新版EN5采用.net 6开发，且安装包内置 desktop 运行库，无需安装PE .net依赖。

由于官方下载地址、版本接口升级到了HTTP2，猜测是为了避免流量盗刷，此项目中使用的 aria2（来自scoop）和 curl（Windows系统自带）均无法正常下载，会提示证书错误（解决方法是更换第三方编译版本或增加不校验证书的选项），故采用360软件宝库的完整版分流（普通下载）作为软件采集源。