### PR TITLE
feat: add 潇然一键装机助理

### DIFF
--- a/tasks/潇然一键装机助理/config.toml
+++ b/tasks/潇然一键装机助理/config.toml
@@ -1,0 +1,46 @@
+#:schema ../../schema/task.json
+# 任务基本信息
+[task]
+name = "潇然一键装机助理"
+category = "安装备份"
+author = "xrgzs"
+url = "https://www.xrgzs.top/xrok"
+
+# 指定使用的模板
+[template]
+scraper = "Global_Page_Match"
+# resolver = ""
+producer = "Recursive_Unzip"
+
+# 使用到的正则
+[regex]
+download_link = 'https://url.xrgzs.top/xrokhpm'
+download_name = '\.HPM'
+# scraper_version = ''
+
+# 通用参数
+[parameter]
+# resolver_cd = []
+# compress_level = 5
+build_manifest = ["${taskName}.wcs","${taskName}/Xiaoran.bat"]
+build_cover = "cover"
+build_delete = ["HPM.config","HPM.key","HPM.WCE.Dense","HPM_Next.WCE"]
+
+# 爬虫模板临时参数
+
+[scraper_temp]
+ua = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:127.0) Gecko/20100101 Firefox/127.0"
+version_page_url = "https://url.xrgzs.top/QiiVersion"
+
+# 自动制作模板要求的参数
+[producer_required]
+shortcutName = "潇然一键装机助理"
+sourceFile = "Xiaoran.bat"
+recursiveUnzipList = []
+
+
+# 额外备注
+# [extra]
+# require_windows = true
+# missing_version = ""
+# weekly = true

--- a/tasks/潇然一键装机助理/cover/潇然一键装机助理.wcs
+++ b/tasks/潇然一键装机助理/cover/潇然一键装机助理.wcs
@@ -1,0 +1,4 @@
+LINK X:\Users\Default\Desktop\潇然一键装机助理,%ProgramFiles%\Edgeless\潇然一键装机助理\Xiaoran.bat,,%ProgramFiles%\Edgeless\潇然一键装机助理\Xiaoran.ico
+
+REGI $HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers\\%ProgramFiles%\Edgeless\潇然一键装机助理\UjyQii.exe=~ GDIDPISCALING DPIUNAWARE
+REGI $HKCU\SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers\\%ProgramFiles%\Edgeless\潇然一键装机助理\UjyQii.exe=~ GDIDPISCALING DPIUNAWARE


### PR DESCRIPTION
潇然一键装机助理是基于优捷易一键装机助理定制的一个方便安装系统及系统维护的工具，同时提供丰富的扩展功能。

相比原版，此定制版本提供更为全面的系统库，并默认去除推广选项。增加启动器，方便自动更新程序版本到最新开发版本。
