### PR TITLE
fix: 潇然一键装机助理请求失败

### DIFF
--- a/tasks/潇然一键装机助理/config.toml
+++ b/tasks/潇然一键装机助理/config.toml
@@ -8,13 +8,13 @@ url = "https://www.xrgzs.top/xrok"
 
 # 指定使用的模板
 [template]
-scraper = "Global_Page_Match"
+scraper = "External"
 # resolver = ""
 producer = "Recursive_Unzip"
 
 # 使用到的正则
 [regex]
-download_link = 'https://url.xrgzs.top/xrokhpm'
+# download_link = ''
 download_name = '\.HPM'
 # scraper_version = ''
 
@@ -29,8 +29,6 @@ build_delete = ["HPM.config","HPM.key","HPM.WCE.Dense","HPM_Next.WCE"]
 # 爬虫模板临时参数
 
 [scraper_temp]
-ua = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:127.0) Gecko/20100101 Firefox/127.0"
-version_page_url = "https://url.xrgzs.top/QiiVersion"
 
 # 自动制作模板要求的参数
 [producer_required]

--- a/tasks/潇然一键装机助理/scraper.ts
+++ b/tasks/潇然一键装机助理/scraper.ts
@@ -1,0 +1,31 @@
+import { Ok, Err, Result } from "ts-results";
+import { ScraperReturned } from "../../src/class";
+
+export default async function (): Promise<Result<ScraperReturned, string>> {
+  // YOUR CODE HERE
+
+  // 尝试从指定URL获取下载信息
+  try {
+    // 发起GET请求获取下载信息
+    const res = await fetch(
+      "https://alist.xrgzs.top/d/pxy/Xiaoran%20Studio/Onekey/QiiVersion.txt",
+      { method: "GET" },
+    );
+    // 如果请求不成功，则返回错误信息
+    if (!res.ok) {
+      return new Err(`Failed to fetch data: ${res.status} ${res.statusText}`);
+    }
+    // 解析响应
+    const ver = await res.text();
+    console.log(ver);
+    // 如果数据有效，返回下载链接信息
+    return new Ok({
+      version: ver,
+      downloadLink:
+        "https://alist.xrgzs.top/d/pxy/Xiaoran%20Studio/Onekey/PE/HotPE/XROK.HPM",
+    });
+    // 如果发生异常，返回错误信息
+  } catch (err) {
+    return new Err(`Fetch error: ${err}`);
+  }
+}


### PR DESCRIPTION
更改为外置爬虫，指定下载线路为全球线路，避免由发布页面请求错误、跳转出错导致的问题。

本地测试：

![](https://github.com/user-attachments/assets/05c0cbc0-e4f6-41c4-b004-9179714ff550)

此下载线路也在我项目的 Github Actions 中使用，应该没有问题。

#111 