### PR TITLE
fix: 希沃白板5配置文件复制路径错误

### DIFF
--- a/tasks/希沃白板5/cover/希沃白板5.wcs
+++ b/tasks/希沃白板5/cover/希沃白板5.wcs
@@ -1,4 +1,4 @@
-FILE %ProgramFiles%\Edgeless\Configs.fkv=>X:\Users\Default\AppData\Seewo\EasiNote5\Data\Configs.fkv
+FILE %ProgramFiles%\Edgeless\Configs.fkv=>X:\Users\Default\AppData\Roaming\Seewo\EasiNote5\Data\Configs.fkv
 LINK X:\Users\Default\Desktop\Ï£ÎÖ°×°å5,%ProgramFiles%\Edgeless\Ï£ÎÖ°×°å5\Main\EasiNote.exe
 
 REGI  $HKEY_LOCAL_MACHINE\SOFTWARE\Classes\.enb\\=iseewo.enb


### PR DESCRIPTION
修复希沃白板5配置文件复制路径错误，修复后能够识别为一体机免登录直接进入大板授课模式