### PR TITLE
fix(Scoop): Trim renaming suffix, prevent getting 40x response

### DIFF
--- a/templates/scrapers/Scoop.ts
+++ b/templates/scrapers/Scoop.ts
@@ -17,17 +17,12 @@ export default async function (
     })
   ).unwrap();
   try {
-    log(
-      `Info: downloadLink:${
-        response["architecture"]?.["64bit"]["url"] ?? response["url"]
-      }`,
-    );
-    log(`Info: Version: ${response["version"]}`);
-    return new Ok({
-      version: response["version"],
-      downloadLink:
-        response["architecture"]?.["64bit"]["url"] ?? response["url"],
-    });
+    const url = response.architecture?.["64bit"]?.url ?? response.url;
+    const downloadLink = url.split("#/")[0];
+    const version = response.version;
+    log(`Info: downloadLink:${downloadLink}`);
+    log(`Info: Version: ${version}`);
+    return new Ok({ version, downloadLink });
   } catch (e) {
     return new Err(
       `Error:Given url doesn't match standard scoop manifest schema, got : ${JSON.stringify(


### PR DESCRIPTION
Scoop中有很多链接都为https://***********.exe#/dl.7z格式，部分服务器如果不移除尾部的文件名会造成下载失败