### PR TITLE
fix: not PECMD var

### DIFF
--- a/templates/producers/Recursive_Unzip.ts
+++ b/templates/producers/Recursive_Unzip.ts
@@ -155,13 +155,13 @@ LINK X:\\Users\\Default\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Progr
   if (obj.addPath) {
     wcsScript += `
 REGI HKCU\\Environment\\\\Path,UserPath
-ENVI #Path=%&UserPath%;%ProgramFiles%\\Edgeless\\${p.taskName}
+ENVI #Path=%UserPath%;%ProgramFiles%\\Edgeless\\${p.taskName}
 `;
   }
   if (obj.addMachinePath) {
     wcsScript += `
 REGI HKLM\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment\\\\Path,MachinePath
-ENVI $Path=%&MachinePath%;%ProgramFiles%\\Edgeless\\${p.taskName}
+ENVI $Path=%MachinePath%;%ProgramFiles%\\Edgeless\\${p.taskName}
 `;
   }
   if (obj.addAppPath) {


### PR DESCRIPTION
此处的获取的 `UserPath` 非 PE 变量 `&UserPath`，会导致原环境变量清空

![](https://github.com/user-attachments/assets/6a19ea2e-eb66-49f8-92fb-2237e35d6e33)
